### PR TITLE
Properly display slippage in arb strategy

### DIFF
--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -62,7 +62,7 @@ const pingpongStrategy = async (jupiter, tokenA, tokenB) => {
 		const outputToken = cache.sideBuy ? tokenB : tokenA;
 
 		const tokdecimals = cache.sideBuy ? inputToken.decimals : outputToken.decimals;
-				
+
 		//console.log('amountToTrade '+amountToTrade);
 		//console.log('slippageBps '+slippage);
 		//console.log('inputToken.address '+inputToken.address);
@@ -70,7 +70,7 @@ const pingpongStrategy = async (jupiter, tokenA, tokenB) => {
 
 		//BNI AMT to TRADE
 		const amountInJSBI = JSBI.BigInt(amountToTrade);
-				
+
 		// check current routes
 		const performanceOfRouteCompStart = performance.now();
 		const routes = await jupiter.computeRoutes({
@@ -102,7 +102,7 @@ const pingpongStrategy = async (jupiter, tokenA, tokenB) => {
 
 		// Alter slippage to be larger based on the profit if enabled in the config
 		// set cache.config.adaptiveSlippage=1 to enable
-		// Profit minus minimum profit	
+		// Profit minus minimum profit
 		// default to the set slippage
 		var slippagerevised = slippage;
 
@@ -118,7 +118,7 @@ const pingpongStrategy = async (jupiter, tokenA, tokenB) => {
 
 				//console.log("Setting slippage to "+slippagerevised);
 				route.slippageBps = slippagerevised;
-		} 
+		}
 
 		// store max profit spotted
 		if (
@@ -137,7 +137,7 @@ const pingpongStrategy = async (jupiter, tokenA, tokenB) => {
 			tokenB,
 			route,
 			simulatedProfit,
-		});	
+		});
 
 		// check profitability and execute tx
 		let tx, performanceOfTx;
@@ -319,15 +319,15 @@ const arbitrageStrategy = async (jupiter, tokenA) => {
 
 		var slippagerevised = slippage;
 
-		if ((simulatedProfit > cache.config.minPercProfit) && cache.config.adaptiveSlippage == 1){
-				var slippagerevised = (100*(simulatedProfit-minPercProfitRnd+(slippage/100))).toFixed(3)
+		if ((simulatedProfit > cache.config.minPercProfit) && cache.config.adaptiveSlippage === 1){
+				slippagerevised = (100*(simulatedProfit-minPercProfitRnd+(slippage/100))).toFixed(3)
 
 				// Set adaptive slippage
 				if (slippagerevised>500) {
 						// Make sure on really big numbers it is only 30% of the total if > 50%
-						var slippagerevised = (0.30*slippagerevised).toFixed(3);
+						slippagerevised = (0.30*slippagerevised).toFixed(3);
 				} else {
-						var slippagerevised = (0.80*slippagerevised).toFixed(3);
+						slippagerevised = (0.80*slippagerevised).toFixed(3);
 				}
 				//console.log("Setting slippage to "+slippagerevised);
 				route.slippageBps = slippagerevised;
@@ -403,7 +403,7 @@ const arbitrageStrategy = async (jupiter, tokenA) => {
 
 				// stop refreshing status
 				clearInterval(printTxStatus);
-              
+
 				//console.log('Calculate trade profit Out');
 				const profit = calculateProfit(tradeEntry.inAmount, tx.outputAmount);
 
@@ -412,13 +412,13 @@ const arbitrageStrategy = async (jupiter, tokenA) => {
 					outAmount: tx.outputAmount || 0,
 					profit,
 					performanceOfTx,
-					error: tx.error?.message || null,
+					error: tx.error?.code === 6001 ? "Slippage Tolerance Exceeded" : tx.error?.message || null,
+					slippage: slippagerevised,
 				};
 
 				// handle TX results
-				if (tx.error) { 			
+				if (tx.error) {
 					// Slippage tolerance exceeded
-					console.log('Swap Error Failed Handler: '+tx.error);
 					await failedSwapHandler(tradeEntry, inputToken, amountToTrade);
 				} else {
 					if (cache.hotkeys.r) {
@@ -498,7 +498,7 @@ const run = async () => {
 
 			// Check the balance
 			var realbalanceTokenA = await balanceCheck( tokenA )
-			
+
 			if (realbalanceTokenA<cache.initialBalance.tokenA){
 				console.error('You do not have enough of the token in your wallet: '+realbalanceTokenA+' < '+cache.initialBalance.tokenA);
 				process.exit();
@@ -528,7 +528,7 @@ const run = async () => {
 
 			// Check the balance
 			var realbalanceTokenA = await balanceCheck( tokenA )
-			
+
 			if (realbalanceTokenA<cache.initialBalance.tokenA){
 				console.log('Balance Lookup is too low for token: '+realbalanceTokenA+' < '+cache.initialBalance.tokenA);
 				process.exit();


### PR DESCRIPTION
Also specifically call out slippage tolerance exceeded as an error as opposed to the current `Unknown error, visit the explorer`

![WindowsTerminal_hZ6iHpef69](https://github.com/cryptopavelsan/solana-jupiter-bot/assets/24514211/ed5dae0d-d3fb-46da-991f-4c937b789c2a)
